### PR TITLE
Default homeserver

### DIFF
--- a/conf/cinny.json
+++ b/conf/cinny.json
@@ -1,0 +1,7 @@
+{
+  "defaultHomeserver": 0,
+  "homeserverList": [
+    "__DEFAULT_HOME_SERVER__"
+  ],
+  "allowCustomHomeservers": true
+}

--- a/manifest.toml
+++ b/manifest.toml
@@ -36,6 +36,14 @@ ram.runtime = "50M"
     type = "path"
     default = "/cinny"
 
+    [install.default_home_server]
+    ask.en = "Choose a default Matrix server for Cinny's login"
+    ask.fr = "Choisissez un serveur Matrix par défault"
+    help.en = "If you're running your own homeserver with Synapse, Dendrite, or Conduit you probably want this to be your homeserver's domain."
+    type = "string"
+    example = "my-own-homeserver.tld"
+    default = "matrix.org"
+
     [install.init_main_permission]
     help.en = "You will usually let visitors access Cinny so that anyone without a Yunohost account can log into Matrix."
     help.fr = "Vous laisserez généralement les visiteurs accéder Cinny pour s'y connecter sans avoir de compte Yunohost."

--- a/scripts/install
+++ b/scripts/install
@@ -29,6 +29,14 @@ ynh_script_progression --message="Configuring NGINX web server..." --weight=1
 ynh_add_nginx_config
 
 #=================================================
+# CINNY CONFIGURATION
+#=================================================
+ynh_script_progression --message="Configuring Cinny..." --weight=1
+
+# Copy over the Cinny configuration file
+ynh_add_config --template="../conf/cinny.json" --destination="$install_dir/config.json"
+
+#=================================================
 # END OF SCRIPT
 #=================================================
 

--- a/scripts/install
+++ b/scripts/install
@@ -36,6 +36,10 @@ ynh_script_progression --message="Configuring Cinny..." --weight=1
 # Copy over the Cinny configuration file
 ynh_add_config --template="../conf/cinny.json" --destination="$install_dir/config.json"
 
+# Fix any permissions in the install dir
+chmod -R o-rwx "$install_dir"
+chown -R $app:www-data "$install_dir"
+
 #=================================================
 # END OF SCRIPT
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -28,7 +28,7 @@ then
 	ynh_script_progression --message="Upgrading source files..." --weight=1
 
 	# Download, check integrity, uncompress and patch the source from app.src
-	ynh_setup_source --dest_dir="$install_dir"
+	ynh_setup_source --dest_dir="$install_dir" --keep="config.json"
 fi
 
 chmod -R o-rwx "$install_dir"


### PR DESCRIPTION
## Problem

- There was no way to configure Cinny to use your own homeserver as the default for logging in

## Solution

- Added a custom Cinny config and expose the homeserver variable in the manifest

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
