### PR TITLE
Use Github workflow to build YNH package supporting custom path

### DIFF
--- a/.github/workflows/ynh-build-on-push-to-testing.yml
+++ b/.github/workflows/ynh-build-on-push-to-testing.yml
@@ -1,0 +1,37 @@
+name: ynh-build-on-push-to-testing
+on:
+  push:
+    branches: [ "testing" ]
+jobs: 
+  ynh-app-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse data from PR
+        id: pr_data
+        run: |
+          echo "VERSION=0.0.0" >> $GITHUB_OUTPUT
+          echo "URL=https://my-test-changelog.tld" >> $GITHUB_OUTPUT
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Build release
+        id: build_release
+        run: | 
+          chmod +x scripts/build
+          ./scripts/build
+      - name: Prepare draft release
+        id: draft_release
+        uses: softprops/action-gh-release@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ steps.build_release.outputs.YNH_ARCHIVE }}
+          tag_name: v${{ steps.pr_data.outputs.VERSION }}
+          draft: true
+          prerelease: false
+          body: |
+            Version built for Yunohost to ensure sub-directory install compatibility using `scripts/build` and `.github/workflows/ynh-build-on-push-to-testing.yml`
+            ### Changelog
+            Cf. upstream release note: ${{ steps.pr_data.outputs.URL }}

--- a/.github/workflows/ynh-build-on-upstream-update.yml
+++ b/.github/workflows/ynh-build-on-upstream-update.yml
@@ -1,0 +1,46 @@
+name: ynh-build-on-upstream-update
+on:
+  pull_request:
+    types: [opened]
+jobs: 
+  ynh-app-release:
+    if: ${{ github.event.pull_request.user.login == 'yunohost-bot' && 
+            startsWith(github.event.pull_request.title, 'Upgrade to v') }} 
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse data from PR
+        id: pr_data
+        run: |
+          echo "VERSION=${${{ github.event.pull_request.title }}#Upgrade to v}" >> $GITHUB_OUTPUT
+          echo "URL=$(${{github.event.pull_request.body}} | grep -o 'http[s]\?://[^ ]\+' | head -1)" >> $GITHUB_OUTPUT
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Build release
+        id: build_release
+        run: | 
+          chmod +x scripts/build
+          ./scripts/build
+      - name: Prepare draft release
+        id: draft_release
+        uses: softprops/action-gh-release@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ steps.build_release.outputs.YNH_ARCHIVE }}
+          tag_name: v${{ steps.pr_data.outputs.VERSION }}
+          draft: true
+          prerelease: false
+          body: |
+            Version built for Yunohost to ensure sub-directory install compatibility using `scripts/build` and `.github/workflows/ynh-build-on-upstream-update.yml`
+            ### Changelog
+            Cf. upstream release note: ${{ steps.pr_data.outputs.URL }}
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+          message: |
+            'Upstream upgrade is now built for YNH and ready to be released in the current repository: ${{ steps.draft_release.outputs.url }}
+             Make sure the release is published before merging this PR.'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/build
+++ b/scripts/build
@@ -1,0 +1,148 @@
+#!/bin/bash
+
+#=================================================
+# BUILD SCRIPT RESOURCES USAGE:
+# Up to 1GB disk space and 5GB RAM. 
+#=================================================
+
+set -x
+
+upstream_owner="cinnyapp"
+upstream_repo="cinny"
+ynh_owner="Yunohost-Apps"
+ynh_repo="cinny_ynh"
+build_node_version=20
+
+#Fill with Github Personal Token to upload release after build (not required if build is part of a Github workflow) - https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
+gh_personal_token="" 
+
+#=================================================
+# DOWNLOAD AND EXTRACT SOURCE
+#=================================================
+last_upstream_version=$(curl --silent "https://api.github.com/repos/${upstream_owner}/${upstream_repo}/releases/latest" | grep -Po "(?<=\"tag_name\": \").*(?=\")")
+build_folder="${upstream_repo}_${last_upstream_version}"
+curl -LJ "https://api.github.com/repos/${upstream_owner}/${upstream_repo}/tarball/${last_upstream_version}" --output "${build_folder}.tar.gz"
+mkdir "$build_folder"
+tar --strip-components=1 -xvf "${build_folder}.tar.gz" -C "./${build_folder}/"
+
+# Add path placeholder
+sed -i "s|base: '/'|base: '/__YNH_SUBDIR_PATH__'|" "$build_folder/build.config.ts"
+
+#=================================================
+# BUILD
+#=================================================
+ynh_archive_name="${build_folder}_ynh.zip"
+pushd "$build_folder"
+    # Call NVM if expected node version differs form current node version
+    current_node_version=$(node -v | cut -c 2- | cut -c 1-${#build_node_version})
+    if [ "$current_node_version" != "$build_node_version" ]; then
+        if [ -f ~/.nvm/nvm.sh ]; then
+            source ~/.nvm/nvm.sh install $build_node_version
+        else
+            echo "Current Node.js version ($current_node_version) not matching building requirement ($build_node_version). Please install expected Node.js version or Node Version Manager (nvm)"
+        fi
+    fi
+
+    # Actual build instructions
+    npm ci && npm run build
+
+    # Package
+    mv "dist" "${ynh_repo}"
+    zip -r $ynh_archive_name "${ynh_repo}"
+    mv $ynh_archive_name "../${ynh_archive_name}"
+popd
+
+#=================================================
+# CLEAN BUILD FOLDER
+#=================================================
+rm -r "${build_folder}"
+rm "${build_folder}.tar.gz"
+
+#=================================================
+# UPLOAD RELEASE
+#=================================================
+
+# Upload with Github Personal Token (local build, i.e. not running a Github Workflow)
+if [[ $gh_personal_token && -z $GITHUB_OUTPUT ]]; then
+    
+    echo "Trying to upload the release to https://github.com/${ynh_owner}/${ynh_repo}/releases/ ..."
+
+    sha256sumarchive=$(sha256sum "$ynh_archive_name" | cut -d' ' -f1)
+
+    if [[ "$@" =~ "push_release" ]]
+    then
+        ## Make a draft release json with a markdown body
+        release='"tag_name": "'$last_upstream_version'", "target_commitish": "master", "name": "'$last_upstream_version'", '
+        body="${upstream_repo^} prebuilt archive for ${ynh_repo}\\n=========\\nPlease refer to upstream ${upstream_repo^} project for the change : https://github.com/$upstream_owner/$upstream_repo/releases\\n\\nSha256sum : $sha256sumarchive"
+        body=\"$body\"
+        body='"body": '$body', '
+        release=$release$body
+        release=$release'"draft": true, "prerelease": false'
+        release='{'$release'}'
+        url="https://api.github.com/repos/$ynh_owner/$ynh_repo/releases"
+        succ=$(curl -H "Authorization: token $gh_personal_token" --data "$release" $url)
+
+        ## In case of success, we upload a file
+        upload_generic=$(echo "$succ" | grep upload_url)
+        if [[ $? -eq 0 ]]; then
+            echo "Release created."
+        else
+            echo "Error creating release!"
+            return
+        fi
+
+        # $upload_generic is like:
+        # "upload_url": "https://uploads.github.com/repos/:owner/:repo/releases/:ID/assets{?name,label}",
+        upload_prefix=$(echo $upload_generic | cut -d "\"" -f4 | cut -d "{" -f1)
+        upload_file="$upload_prefix?name=$ynh_archive_name"
+
+        echo "Start uploading first file"
+        i=0
+        upload_ok=false
+        while [ $i -le 4 ]; do
+            i=$((i+1))
+            # Download file
+            set +e
+            succ=$(curl -H "Authorization: token $gh_personal_token" \
+                -H "Content-Type: $(file -b --mime-type $ynh_archive_name)" \
+                -H "Accept: application/vnd.github.v3+json" \
+                --data-binary @$ynh_archive_name $upload_file)
+            res=$?
+            set -e
+            if [ $res -ne 0 ]; then
+                echo "Curl upload failled"
+                continue
+            fi
+            echo "Upload done, check result"
+
+            set +eu
+            download=$(echo "$succ" | egrep -o "browser_download_url.+?")
+            res=$?
+            if [ $res -ne 0 ] || [ -z "$download" ]; then
+                set -eu
+                echo "Result upload error"
+                continue
+            fi
+            set -eu
+            echo "$download" | cut -d: -f2,3 | cut -d\" -f2
+            echo "Upload OK"
+            upload_ok=true
+            break
+        done
+        
+        set +x  
+
+        if ! $upload_ok; then
+            echo "Upload completely failed, exit"
+            exit 1
+        fi
+    fi
+
+    exit 0
+
+# Script run with Github Workflow or with empty $gh_personal_token
+else
+    if [[ $GITHUB_OUTPUT ]]; then echo "YNH_ARCHIVE=${ynh_archive_name}" >> $GITHUB_OUTPUT; fi #export var for Github Workflow
+    echo "Build completed but not uploaded - missing Github Token"
+    set +x 
+fi

--- a/scripts/install
+++ b/scripts/install
@@ -17,6 +17,13 @@ ynh_script_progression --message="Setting up source files..." --weight=1
 # Download, check integrity, uncompress and patch the source from app.src
 ynh_setup_source --dest_dir="$install_dir"
 
+# Prepare $newpath for string replacement (empty if $path is root or $path if subdir is defined)
+newpath=""
+if [[ $path != '/' ]]; then newpath=$path; fi
+
+# Replace path placeholder recursively in all files of the app folder
+grep -rli '/__YNH_SUBDIR_PATH__' $install_dir/* | xargs sed -i "s@/__YNH_SUBDIR_PATH__@$newpath@g"
+
 chmod -R o-rwx "$install_dir"
 chown -R "$app:www-data" "$install_dir"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -9,10 +9,6 @@
 source _common.sh
 source /usr/share/yunohost/helpers
 
-if [[ "$path" != "/" ]]; then
-    ynh_die "Installing Cinny on a subpath is not supported anymore (see https://github.com/YunoHost-Apps/cinny_ynh/pull/66)"
-fi
-
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
@@ -20,6 +16,13 @@ ynh_script_progression --message="Upgrading source files..." --weight=1
 
 # Download, check integrity, uncompress and patch the source from app.src
 ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="config.json"
+
+# Prepare $newpath for string replacement (empty if $path is root or $path if subdir is defined)
+newpath=""
+if [[ $path != '/' ]]; then newpath=$path; fi
+
+# Replace path placeholder recursively in all files of the app folder
+grep -rli '/__YNH_SUBDIR_PATH__' $install_dir/* | xargs sed -i "s@/__YNH_SUBDIR_PATH__@$newpath@g"
 
 chmod -R o-rwx "$install_dir"
 chown -R "$app:www-data" "$install_dir"


### PR DESCRIPTION
## Problem

Custom path install not supported with current cinny_ynh version

## Solution

Use github workflow to build a specific package supporting YNH custom path install
1. after that a first release has to be created using workflow triggered on every push to testing branch. It will create a draft release where sample versioning/text should be corrected and then published.
2. add path to the release in the manifest
3. merge PR to master
4. you may want to disable manually the workflow triggered on every push to testing branch, to enable it only when needed. The main workflow is triggered everytime it detect a PR from yunohost-bot mentioning an upgrade available (based on manifest autoupdate's strategy).

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The code base of the PR comes mostly from that app [it-tools_ynh](https://github.com/YunoHost-Apps/it-tools_ynh) where it seems to work properly:
   - [x] GH workflow when push on testing works fine
   - [x] install script working and app overall navigation was tested manually  
   - [x] CI passed
   - [ ] GH workflow when pull request is yet to be tested
   - [ ] CI says it's fine, but I wonder whether path should not be modified when changing URL, or restoring on a different path - to be checked 
- [ ] Code for this app has been manually tested

